### PR TITLE
Add Google Home Config Name

### DIFF
--- a/node-red-google-home-notify.html
+++ b/node-red-google-home-notify.html
@@ -68,6 +68,10 @@
     <a id="node-config-lookup-ipaddress" class="btn"><i id="node-config-lookup-ipaddress-icon" class="fa fa-search"></i></a>
   </div>
   <div class="form-row">
+    <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-config-input-name" style="width:60%;" placeholder="Google Home Mini"/>
+  </div>
+  <div class="form-row">
     <label for="node-input-language"><i class="fa fa-globe"></i>  Language</label>
     <select id="node-input-language" style="width:60%;">
           <option value="en"> English</option>

--- a/node-red-google-home-notify.html
+++ b/node-red-google-home-notify.html
@@ -7,14 +7,14 @@
         required: true
       },
       name: {
-        value: "",
+        value: ""
       },
       language: {
         value: "en"
       }
     },
     label: function () {
-      return this.ipaddress || this.name;
+      return this.name || this.ipaddress;
     },
     oneditprepare: function () {
       var node = this;

--- a/node-red-google-home-notify.html
+++ b/node-red-google-home-notify.html
@@ -6,12 +6,15 @@
         value: "",
         required: true
       },
+      name: {
+        value: "",
+      },
       language: {
         value: "en"
       }
     },
     label: function () {
-      return this.ipaddress;
+      return this.ipaddress || this.name;
     },
     oneditprepare: function () {
       var node = this;
@@ -106,7 +109,7 @@
     inputs: 1,
     outputs: 0,
     label: function () {
-      return this.name || "Google Home Notify";
+      return this.configname || this.name || "Google Home Notify";
     }
   });
 </script>

--- a/node-red-google-home-notify.js
+++ b/node-red-google-home-notify.js
@@ -7,6 +7,7 @@ module.exports = function (RED) {
 
     this.ipaddress = n.ipaddress;
     this.language = n.language;
+    this.name = n.name;
 
     //Prepare language Select Box
     var obj = require('./languages');

--- a/node-red-google-home-notify.js
+++ b/node-red-google-home-notify.js
@@ -71,6 +71,7 @@ module.exports = function (RED) {
 
     //Validate config node
     var config = RED.nodes.getNode(n.server);
+    this.configname = config.name;
     if (config === null || config === undefined) {
       node.status({
         fill: "red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-google-home-notify",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "node-red-google-home-notify.js",
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-google-home-notify",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "node-red-google-home-notify.js",
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-google-home-notify",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "node-red-google-home-notify.js",
   "node-red": {
     "nodes": {


### PR DESCRIPTION
I was really tired of memorizing IP addresses for my Google Homes, and having to double check previous Google Home nodes. This adds a name property to the google home config.